### PR TITLE
Updated website url

### DIFF
--- a/resume.json
+++ b/resume.json
@@ -5,7 +5,7 @@
         "picture": "https://lh3.googleusercontent.com/-PhcInTMjUFs/SapDre47OOI/AAAAAAAABNY/KVkFm2hIeCU/s165/010_1046.JPG",
         "email": "jason@teamkerney.com",
         "phone": "",
-        "website": "jason.teamkerney.com",
+        "website": "http://jason.teamkerney.com",
         "summary": "Jason first started programming in 1988 when he purchased a Commodore64 and learned Commodore Basic.  He quickly discovered that evenings and weekends disappeared. He has continued to pursue the field of programming with an ever growing interest. He is determined to be the very best he can be and is never satisfied with what he has learned.",
         "location": {
             "address": "",


### PR DESCRIPTION
Your current website link goes to http://resume.jason.teamkerney.com/jason.teamkerney.com instead of http://jason.teamkerney.com. This change should fix it.
